### PR TITLE
fix domain in config

### DIFF
--- a/lightning-config.php
+++ b/lightning-config.php
@@ -7,7 +7,7 @@ use PhpLightning\Config\LightningConfig;
 
 return (new LightningConfig())
     ->setMode('test')
-    ->setDomain('https://domain.com')
+    ->setDomain('domain.com')
     ->setReceiver('receiver')
     ->setMinSendable(10_000)
     ->setMaxSendable(1_000_000_000)


### PR DESCRIPTION
The current config gives a callback-url with two `https://`
```
vendor/bin/lnaddress callback-url
{
    "callback": "https:\/\/https:\/\/domain.com\/receiver",
    "maxSendable": 1000000000,
    "minSendable": 10000,
    "metadata": "[[\"text\/plain\",\"Pay to receiver@https:\/\/domain.com\"],[\"text\/identifier\",\"receiver@https:\/\/domain.com\"]]",
    "tag": "payRequest",
    "commentAllowed": false
}
```

this pr fixes it to have an expected value 

```
{
    "callback": "https:\/\/domain.com\/receiver",
    "maxSendable": 1000000000,
    "minSendable": 10000,
    "metadata": "[[\"text\/plain\",\"Pay to receiver@domain.com\"],[\"text\/identifier\",\"receiver@domain.com\"]]",
    "tag": "payRequest",
    "commentAllowed": false
}
```